### PR TITLE
fix get_current_service function

### DIFF
--- a/dnscrypt-proxy-switcher.10s.sh
+++ b/dnscrypt-proxy-switcher.10s.sh
@@ -60,8 +60,8 @@ get_current_service() {
 		if [ -n "$sdev" ]; then
 			ifout="$(ifconfig "$sdev" 2>/dev/null)"
 			if echo "$ifout" | grep -Fq 'status: active'; then
-                if [ "${sname}" == 'USB 10/100/1000 LAN' ]; then
-                        currentservice="$sname ($sdev)"
+                if [ "$sname" == 'USB 10/100/1000 LAN' ]; then
+                        currentservice="${sname} ($sdev)"
                         break
                 else
                         currentservice="$sname"
@@ -69,7 +69,7 @@ get_current_service() {
                 fi
 			fi
 		fi
-	done <<<$(echo "$services")
+	done <<<"$(echo "${services}")"
 
 	if [ -n "$currentservice" ]; then
 		echo "$currentservice"

--- a/dnscrypt-proxy-switcher.10s.sh
+++ b/dnscrypt-proxy-switcher.10s.sh
@@ -69,7 +69,7 @@ get_current_service() {
                 fi
 			fi
 		fi
-	done <<<"$(echo "${services}")"
+	done <<<"${services}"
 
 	if [ -n "$currentservice" ]; then
 		echo "$currentservice"

--- a/dnscrypt-proxy-switcher.10s.sh
+++ b/dnscrypt-proxy-switcher.10s.sh
@@ -54,17 +54,22 @@ ospatch=$(echo "$osversion" | awk -F. '{print $3}')
 
 get_current_service() {
 	services=$(networksetup -listnetworkserviceorder | grep -F 'Hardware Port')
-	echo "$services" | while read -r line; do
+	while read -r line; do
 		sname=$(echo "$line" | awk -F "(, )|(: )|[)]" '{print $2}')
 		sdev=$(echo "$line" | awk -F "(, )|(: )|[)]" '{print $4}')
 		if [ -n "$sdev" ]; then
 			ifout="$(ifconfig "$sdev" 2>/dev/null)"
 			if echo "$ifout" | grep -Fq 'status: active'; then
-				currentservice="$sname"
-				break
+                if [ "${sname}" == 'USB 10/100/1000 LAN' ]; then
+                        currentservice="$sname ($sdev)"
+                        break
+                else
+                        currentservice="$sname"
+                        break
+                fi
 			fi
 		fi
-	done
+	done <<<$(echo "$services")
 
 	if [ -n "$currentservice" ]; then
 		echo "$currentservice"


### PR DESCRIPTION
When using multiple "USB to LAN" interfaces with name such as "USB 10/100/1000 LAN (enX)" the method `get_current_service`does not detect the "Hardware Port" (aka service name) correctly. 

Also changed the while loop so that the `currentservice` global variable can be defined properly.